### PR TITLE
Update num-complex to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ features = ["private-docs-rs"]
 
 [dependencies]
 libc = "0.2.76"
-num-complex = { version = "0.3.0", default-features = false }
+num-complex = { version = "0.4.0", default-features = false }
 tensorflow-internal-macros = { version = "=0.0.1", path = "tensorflow-internal-macros" }
 tensorflow-sys = { version = "0.19.0", path = "tensorflow-sys" }
 byteorder = "1.3.4"


### PR DESCRIPTION
This is consistent with the internal version bump in ndarray 0.15, and is necessary to prevent downstream conflicts.