### PR TITLE
Imp/rustup

### DIFF
--- a/tensorflow-sys/Cargo.toml
+++ b/tensorflow-sys/Cargo.toml
@@ -26,7 +26,7 @@ cfg-if = { version = "1.0.0", optional = true }
 log = { version = "0.4.17", optional = true }
 
 [build-dependencies]
-curl = "0.4.44"
+curl = { version = "0.4.44", default-features = false, features = ["rustls"] }
 flate2 = "1.0.24"
 pkg-config = "0.3.25"
 semver = "1.0.13"

--- a/tensorflow-sys/build.rs
+++ b/tensorflow-sys/build.rs
@@ -222,20 +222,32 @@ fn install_prebuilt() {
 
     // Download the tarball.
     if !file_name.exists() {
-        let f = File::create(&file_name).unwrap();
-        let mut writer = BufWriter::new(f);
-        let mut easy = Easy::new();
-        easy.url(&binary_url).unwrap();
-        easy.write_function(move |data| Ok(writer.write(data).unwrap()))
-            .unwrap();
-        easy.perform().unwrap();
+        if let Ok(output) = curl_cli(&binary_url, &file_name) {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            if output.status.success() {
+                if !stdout.is_empty() {
+                    eprintln!("STDOUT(curl): {stdout}");
+                }
+            } else {
+                eprintln!("STDERR(curl): {stderr}");
+            }
+        } else {
+            let f = File::create(&file_name).unwrap();
+            let mut writer = BufWriter::new(f);
+            let mut easy = Easy::new();
+            easy.url(&binary_url).unwrap();
+            easy.write_function(move |data| Ok(writer.write(data).unwrap()))
+                .unwrap();
+            easy.perform().unwrap();
 
-        let response_code = easy.response_code().unwrap();
-        if response_code != 200 {
-            panic!(
-                "Unexpected response code {} for {}",
-                response_code, binary_url
-            );
+            let response_code = easy.response_code().unwrap();
+            if response_code != 200 {
+                panic!(
+                    "Unexpected response code {} for {}",
+                    response_code, binary_url
+                );
+            }
         }
     }
 
@@ -474,4 +486,13 @@ fn check_bazel() -> Result<(), Box<dyn Error>> {
         return Err("Did not find version number in `bazel version` output.".into());
     }
     Ok(())
+}
+
+fn curl_cli(url: &str, output: &Path) -> io::Result<std::process::Output> {
+    Command::new("curl")
+        .arg("--silent")
+        .arg("--output")
+        .arg(output)
+        .arg(url)
+        .output()
 }


### PR DESCRIPTION
In order to build with Rust > 1.80 I needed to drop dependency on `openssl` (which was pulled in via `curl`). The way it worked is really hacky, but the net effect is that we can drop `openssl` completely 🎉 
(Not only I had to configure `curl` to avoid using openssl, but also make it first try CLI and then fall back to the original implementation - the `rustls`-based `curl` chokes on HTTPS)